### PR TITLE
remove $SHELL

### DIFF
--- a/gh-ghq-cd
+++ b/gh-ghq-cd
@@ -31,4 +31,3 @@ check
 selected="$(choose)"
 [ -n "${selected}" ] || exit 1
 \cd ${selected}
-$SHELL


### PR DESCRIPTION
#  Summary
The use of $SHELL forces a change to bash in my environment. Removing $SHELL resolves my issue and appears not to have any side effects.

# Detail
In the current script, the $SHELL variable is used to determine which shell to activate when running the gh-ghq-cd command. However, this has led to an unintended consequence when the script is executed from PowerShell in a Windows environment. The $SHELL variable defaults to invoking bash, which in my setup, triggers MSYS2—a Linux emulator. This switch to MSYS2's bash not only overrides the native PowerShell environment but effectively disables its functionality, as the script's control is transferred to the emulator.

The negative impact of this is twofold. Firstly, it leads to a disruptive user experience by unexpectedly moving from a native Windows shell to a Linux-like environment. Secondly, it can cause confusion and potential issues if the user does not expect or understand why their shell has suddenly changed, especially since MSYS2 behaves differently compared to standard PowerShell.

![gh-ghq-cd](https://github.com/cappyzawa/gh-ghq-cd/assets/149961262/c6f8653f-f000-48d6-aadb-5caa974c2da5)

To showcase this issue, I have attached the GIF where you can see the gh-ghq-cd command being called from PowerShell, only to have the environment forcibly changed to MSYS2's bash. In scenarios where MSYS2 is not installed, the script would alternatively search for and launch bash.exe, potentially initiating a WSL2 session. This behavior is clearly outside the expected functionality when operating within the PowerShell context.

To resolve this, I have removed the invocation of $SHELL, thereby preserving the current shell environment. This change ensures that PowerShell remains the active shell after the script's execution, maintaining the expected behavior and environment consistency. Post-removal testing has confirmed that there are no side effects, and PowerShell's functionality remains intact.
