### PR TITLE
feat: add tmux pane split options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,71 @@ gh ghq-cd
 
 # If you set "cd" as an alias for ghq-cd
 gh cd
+```
 
-# If you want to open the selected repository with tmux new window
-gh cd -n
+### Tmux Integration
+
+When running inside tmux, you can use additional options:
+
+```bash
+# Open in new tmux window
+gh cd -w
+
+# Open in new pane (vertical split, default)
+gh cd -p
+
+# Open in new pane with 2 sub-panes (vertical + horizontal split)
+gh cd -p 2
+```
+
+#### Pane Split Direction
+
+```bash
+# Vertical split (default)
+gh cd -p -V
+
+# Horizontal split
+gh cd -p -H
+
+# With 2 sub-panes
+gh cd -p 2 -V    # vertical + top/bottom
+gh cd -p 2 -H    # horizontal + left/right
+```
+
+#### Layout Examples
+
+**`gh cd -p` (vertical split)**
+```
+┌─────────┬─────────┐
+│ existing│   new   │
+│  pane   │  pane   │
+└─────────┴─────────┘
+```
+
+**`gh cd -p 2` (vertical + 2 sub-panes)**
+```
+┌─────────┬─────────┐
+│ existing│   new   │ ← focus here
+├─────────┼─────────┤
+│         │   new   │
+└─────────┴─────────┘
+```
+
+**`gh cd -p -H` (horizontal split)**
+```
+┌───────────────────┐
+│   existing pane   │
+├───────────────────┤
+│     new pane      │
+└───────────────────┘
+```
+
+**`gh cd -p 2 -H` (horizontal + 2 sub-panes)**
+```
+┌───────────────────┐
+│   existing pane   │
+├─────────┬─────────┤
+│   new   │   new   │
+│ ← focus │         │
+└─────────┴─────────┘
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,18 @@ use crate::selection::select_repository;
 use crate::shell;
 use crate::tmux::{NoopTmuxClient, SystemTmuxClient, TmuxClient, WindowConfig};
 
+/// Mode of operation for tmux
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TmuxMode {
+    /// Use current pane (cd + window rename)
+    #[default]
+    CurrentPane,
+    /// Create new window
+    NewWindow,
+    /// Create new pane with specified pane count and orientation
+    NewPane { count: u8, horizontal: bool },
+}
+
 #[derive(Parser)]
 #[command(name = "gh-ghq-cd")]
 #[command(about = "cd into ghq managed repositories")]
@@ -20,6 +32,43 @@ struct Args {
     /// [DEPRECATED] Use -w instead
     #[arg(short = 'n', hide = true)]
     deprecated_new_window: bool,
+
+    /// Open in new tmux pane (1 = single pane, 2 = split into 2 panes)
+    #[arg(short = 'p', long = "new-pane", num_args = 0..=1, default_missing_value = "1", value_parser = clap::value_parser!(u8).range(1..=2))]
+    new_pane: Option<u8>,
+
+    /// Use vertical split (default, only with -p)
+    #[arg(
+        short = 'V',
+        long = "vertical",
+        requires = "new_pane",
+        conflicts_with = "horizontal"
+    )]
+    vertical: bool,
+
+    /// Use horizontal split (only with -p)
+    #[arg(
+        short = 'H',
+        long = "horizontal",
+        requires = "new_pane",
+        conflicts_with = "vertical"
+    )]
+    horizontal: bool,
+}
+
+impl Args {
+    fn tmux_mode(&self) -> TmuxMode {
+        if let Some(count) = self.new_pane {
+            TmuxMode::NewPane {
+                count,
+                horizontal: self.horizontal,
+            }
+        } else if self.new_window || self.deprecated_new_window {
+            TmuxMode::NewWindow
+        } else {
+            TmuxMode::CurrentPane
+        }
+    }
 }
 
 /// Entry point for the application
@@ -66,12 +115,12 @@ pub fn run() -> Result<()> {
         Box::new(NoopTmuxClient)
     };
 
-    let new_window = args.new_window || args.deprecated_new_window;
-    run_with_deps(new_window, use_tmux, &env, &checker, &runner, tmux.as_ref())
+    let mode = args.tmux_mode();
+    run_with_deps(mode, use_tmux, &env, &checker, &runner, tmux.as_ref())
 }
 
 fn run_with_deps(
-    new_window: bool,
+    mode: TmuxMode,
     use_tmux: bool,
     env: &dyn Environment,
     checker: &dyn CommandChecker,
@@ -89,36 +138,48 @@ fn run_with_deps(
         return Ok(());
     }
 
-    handle_selection(&selected, new_window, use_tmux, env, tmux)
+    handle_selection(&selected, mode, use_tmux, env, tmux)
 }
 
 fn handle_selection(
     selected: &str,
-    new_window_flag: bool,
+    mode: TmuxMode,
     use_tmux: bool,
     env: &dyn Environment,
     tmux: &dyn TmuxClient,
 ) -> Result<()> {
-    let new_window = new_window_flag && use_tmux;
-
     let repo_name = Path::new(selected)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or(selected);
 
-    if new_window {
-        let cfg = WindowConfig::new(repo_name, selected);
-        tmux.new_window(&cfg)?;
+    // Apply tmux mode only when inside tmux
+    let effective_mode = if use_tmux {
+        mode
     } else {
-        // Change directory and start shell
-        env.set_current_dir(selected)?;
+        TmuxMode::CurrentPane
+    };
 
-        if use_tmux {
-            tmux.rename_window(repo_name)?
+    match effective_mode {
+        TmuxMode::NewWindow => {
+            let cfg = WindowConfig::new(repo_name, selected);
+            tmux.new_window(&cfg)?;
         }
+        TmuxMode::NewPane { count, horizontal } => {
+            let cfg = WindowConfig::new(repo_name, selected);
+            tmux.new_pane(&cfg, count, horizontal)?;
+        }
+        TmuxMode::CurrentPane => {
+            // Change directory and start shell
+            env.set_current_dir(selected)?;
 
-        let shell_path = env.var("SHELL").unwrap_or_else(|| String::from("/bin/sh"));
-        shell::exec(&shell_path)?;
+            if use_tmux {
+                tmux.rename_window(repo_name)?
+            }
+
+            let shell_path = env.var("SHELL").unwrap_or_else(|| String::from("/bin/sh"));
+            shell::exec(&shell_path)?;
+        }
     }
 
     Ok(())
@@ -157,6 +218,7 @@ mod tests {
     struct MockTmuxClient {
         new_window_calls: RefCell<Vec<String>>,
         rename_window_calls: RefCell<Vec<String>>,
+        new_pane_calls: RefCell<Vec<(String, u8, bool)>>,
     }
 
     impl MockTmuxClient {
@@ -164,6 +226,7 @@ mod tests {
             Self {
                 new_window_calls: RefCell::new(Vec::new()),
                 rename_window_calls: RefCell::new(Vec::new()),
+                new_pane_calls: RefCell::new(Vec::new()),
             }
         }
     }
@@ -178,6 +241,13 @@ mod tests {
             self.rename_window_calls.borrow_mut().push(name.to_string());
             Ok(())
         }
+
+        fn new_pane(&self, cfg: &WindowConfig, count: u8, horizontal: bool) -> Result<()> {
+            self.new_pane_calls
+                .borrow_mut()
+                .push((cfg.name.clone(), count, horizontal));
+            Ok(())
+        }
     }
 
     #[test]
@@ -187,8 +257,8 @@ mod tests {
 
         let result = handle_selection(
             "/home/user/ghq/github.com/owner/repo",
-            true, // new_window_flag
-            true, // use_tmux
+            TmuxMode::NewWindow,
+            true,
             &env,
             &tmux,
         );
@@ -197,5 +267,87 @@ mod tests {
         assert_eq!(tmux.new_window_calls.borrow().len(), 1);
         assert_eq!(tmux.new_window_calls.borrow()[0], "repo");
         assert!(env.set_dir_calls.borrow().is_empty());
+        assert!(tmux.new_pane_calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_handle_selection_new_pane_in_tmux() {
+        let env = MockEnvironment::new();
+        let tmux = MockTmuxClient::new();
+
+        let result = handle_selection(
+            "/home/user/ghq/github.com/owner/repo",
+            TmuxMode::NewPane {
+                count: 2,
+                horizontal: false,
+            },
+            true,
+            &env,
+            &tmux,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(tmux.new_pane_calls.borrow().len(), 1);
+        assert_eq!(
+            tmux.new_pane_calls.borrow()[0],
+            ("repo".to_string(), 2, false)
+        );
+        assert!(env.set_dir_calls.borrow().is_empty());
+        assert!(tmux.new_window_calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_args_tmux_mode() {
+        // -p 2
+        let args = Args {
+            new_window: false,
+            deprecated_new_window: false,
+            new_pane: Some(2),
+            vertical: false,
+            horizontal: false,
+        };
+        assert_eq!(
+            args.tmux_mode(),
+            TmuxMode::NewPane {
+                count: 2,
+                horizontal: false
+            }
+        );
+
+        // -p -H
+        let args = Args {
+            new_window: false,
+            deprecated_new_window: false,
+            new_pane: Some(1),
+            vertical: false,
+            horizontal: true,
+        };
+        assert_eq!(
+            args.tmux_mode(),
+            TmuxMode::NewPane {
+                count: 1,
+                horizontal: true
+            }
+        );
+
+        // -w
+        let args = Args {
+            new_window: true,
+            deprecated_new_window: false,
+            new_pane: None,
+            vertical: false,
+            horizontal: false,
+        };
+        assert_eq!(args.tmux_mode(), TmuxMode::NewWindow);
+
+        // no flags
+        let args = Args {
+            new_window: false,
+            deprecated_new_window: false,
+            new_pane: None,
+            vertical: false,
+            horizontal: false,
+        };
+        assert_eq!(args.tmux_mode(), TmuxMode::CurrentPane);
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -21,6 +21,7 @@ impl WindowConfig {
 pub trait TmuxClient {
     fn new_window(&self, cfg: &WindowConfig) -> Result<()>;
     fn rename_window(&self, name: &str) -> Result<()>;
+    fn new_pane(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()>;
 }
 
 pub struct SystemTmuxClient;
@@ -43,6 +44,49 @@ impl TmuxClient for SystemTmuxClient {
         runner.run("tmux", &["rename-window", name])?;
         Ok(())
     }
+
+    fn new_pane(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()> {
+        let runner = SystemCommandRunner;
+        let start_dir = cfg
+            .start_dir
+            .to_str()
+            .context("repository path contains invalid UTF-8")?;
+
+        // Primary split direction:
+        // - vertical (default): -hf (horizontal split with full height, creates left/right)
+        // - horizontal: -vf (vertical split with full width, creates top/bottom)
+        let primary_split = if horizontal { "-vf" } else { "-hf" };
+        runner.run("tmux", &["split-window", primary_split, "-c", start_dir])?;
+
+        // Set pane title for the new pane
+        runner.run("tmux", &["select-pane", "-T", &cfg.name])?;
+
+        if pane_count >= 2 {
+            // Secondary split (perpendicular to primary):
+            // - vertical primary: -v (split top/bottom within the new pane)
+            // - horizontal primary: -h (split left/right within the new pane)
+            let secondary_split = if horizontal { "-h" } else { "-v" };
+            runner.run("tmux", &["split-window", secondary_split, "-c", start_dir])?;
+
+            // Navigate and set titles for both sub-panes
+            let nav_to_first = if horizontal { "-L" } else { "-U" };
+            let nav_to_second = if horizontal { "-R" } else { "-D" };
+
+            runner.run("tmux", &["select-pane", nav_to_first])?;
+            runner.run("tmux", &["select-pane", "-T", &cfg.name])?;
+
+            runner.run("tmux", &["select-pane", nav_to_second])?;
+            runner.run("tmux", &["select-pane", "-T", &cfg.name])?;
+
+            // Return to first sub-pane (focus)
+            runner.run("tmux", &["select-pane", nav_to_first])?;
+        }
+
+        // Equalize pane sizes
+        runner.run("tmux", &["select-layout", "-E"])?;
+
+        Ok(())
+    }
 }
 
 impl TmuxClient for NoopTmuxClient {
@@ -50,6 +94,9 @@ impl TmuxClient for NoopTmuxClient {
         Ok(())
     }
     fn rename_window(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+    fn new_pane(&self, _: &WindowConfig, _: u8, _: bool) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Deprecate `-n` option in favor of `-w` for new window creation
- Add `-p` / `--new-pane` option for flexible tmux pane splits
- Add `-V` / `--vertical` and `-H` / `--horizontal` options for split direction

## New Options

| Option | Description |
|--------|-------------|
| `-w` / `--new-window` | Open in new tmux window (replaces `-n`) |
| `-p` / `--new-pane` | Open in new pane (1 = single, 2 = split into 2) |
| `-V` / `--vertical` | Vertical split (default) |
| `-H` / `--horizontal` | Horizontal split |

## Layout Examples

```
# cargo run -- -p (vertical split)
┌─────────┬─────────┐
│ existing│   new   │
└─────────┴─────────┘

# cargo run -- -p 2 (vertical + 2 sub-panes)
┌─────────┬─────────┐
│ existing│   new   │ ← focus
├─────────┼─────────┤
│         │   new   │
└─────────┴─────────┘

# cargo run -- -p -H (horizontal split)
┌───────────────────┐
│   existing pane   │
├───────────────────┤
│     new pane      │
└───────────────────┘
```

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] Manual test: `cargo run -- -w` creates new window
- [x] Manual test: `cargo run -- -p` creates vertical split
- [x] Manual test: `cargo run -- -p 2` creates vertical split with 2 sub-panes
- [x] Manual test: `cargo run -- -p -H` creates horizontal split
- [x] Manual test: `cargo run -- -n` shows deprecation warning