### PR TITLE
feat: allow combining -w and -p options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ gh cd -p
 
 # Open in new pane with 2 sub-panes (vertical + horizontal split)
 gh cd -p 2
+
+# Open in new window with pane split
+gh cd -w -p
+
+# Open in new window with 2 sub-panes
+gh cd -w -p 2
 ```
 
 #### Pane Split Direction
@@ -62,6 +68,10 @@ gh cd -p -H
 # With 2 sub-panes
 gh cd -p 2 -V    # vertical + top/bottom
 gh cd -p 2 -H    # horizontal + left/right
+
+# New window with horizontal split
+gh cd -w -p -H
+gh cd -w -p 2 -H
 ```
 
 #### Layout Examples


### PR DESCRIPTION
## Summary
- Enable using `-w` (new window) and `-p` (pane split) options together
- `-w -p 2` creates a new window with 2 panes (top/bottom or left/right)
- Direction options (`-V`/`-H`) work with the combination

## Test plan
- [x] `cargo run -- -w -p 2` creates new window with top/bottom 2 panes
- [x] `cargo run -- -w -p 2 -H` creates new window with left/right 2 panes
- [x] `cargo run -- -w` still works (new window only)
- [x] `cargo run -- -p 2` still works (pane split in current window)