### PR TITLE
feat: add -c/--command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ gh cd -w -p -H
 gh cd -w -p 2 -H
 ```
 
+#### Run Command in New Pane/Window
+
+```bash
+# Run a command in the new pane/window
+gh cd -w -c "claude"
+gh cd -p -c "npm run dev"
+gh cd -w -p -c "claude"
+```
+
+> [!NOTE]
+> `-c` cannot be used with `-p 2` (multiple panes)
+
 #### Layout Examples
 
 **`gh cd -p` (vertical split)**

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -22,6 +22,7 @@ pub trait TmuxClient {
     fn new_window(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()>;
     fn rename_window(&self, name: &str) -> Result<()>;
     fn new_pane(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()>;
+    fn send_keys(&self, keys: &str) -> Result<()>;
 }
 
 pub struct SystemTmuxClient;
@@ -114,6 +115,12 @@ impl TmuxClient for SystemTmuxClient {
 
         Ok(())
     }
+
+    fn send_keys(&self, keys: &str) -> Result<()> {
+        let runner = SystemCommandRunner;
+        runner.run("tmux", &["send-keys", keys, "Enter"])?;
+        Ok(())
+    }
 }
 
 impl TmuxClient for NoopTmuxClient {
@@ -124,6 +131,9 @@ impl TmuxClient for NoopTmuxClient {
         Ok(())
     }
     fn new_pane(&self, _: &WindowConfig, _: u8, _: bool) -> Result<()> {
+        Ok(())
+    }
+    fn send_keys(&self, _: &str) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add `-c`/`--command` option to run a command in the new pane/window
- Command is sent via `tmux send-keys`
- `-c` cannot be used with `-p 2` (multiple panes)

## Test plan
- [x] `cargo run -- -w -c "echo test"` runs command in new window
- [x] `cargo run -- -p -c "echo test"` runs command in new pane
- [x] `cargo run -- -p 2 -c "echo test"` returns error