### PR TITLE
feat: add zellij terminal multiplexer support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ pub mod app;
 pub mod command;
 pub mod environment;
 pub mod ghq;
+pub mod multiplexer;
 pub mod selection;
 pub mod shell;
-pub mod tmux;
 
 pub use app::run;

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -18,17 +18,17 @@ impl WindowConfig {
     }
 }
 
-pub trait TmuxClient {
+pub trait Multiplexer {
     fn new_window(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()>;
     fn rename_window(&self, name: &str) -> Result<()>;
     fn new_pane(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()>;
     fn send_keys(&self, keys: &str) -> Result<()>;
 }
 
-pub struct SystemTmuxClient;
-pub struct NoopTmuxClient;
+pub struct TmuxClient;
+pub struct NoopClient;
 
-impl TmuxClient for SystemTmuxClient {
+impl Multiplexer for TmuxClient {
     fn new_window(&self, cfg: &WindowConfig, pane_count: u8, horizontal: bool) -> Result<()> {
         let runner = SystemCommandRunner;
         let start_dir = cfg
@@ -123,7 +123,7 @@ impl TmuxClient for SystemTmuxClient {
     }
 }
 
-impl TmuxClient for NoopTmuxClient {
+impl Multiplexer for NoopClient {
     fn new_window(&self, _: &WindowConfig, _: u8, _: bool) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Refactor tmux module to generic multiplexer abstraction
- Add zellij terminal multiplexer support with automatic detection via `ZELLIJ` environment variable
- Map tmux operations to zellij equivalents (new-tab, new-pane, rename-tab, rename-pane, write-chars)

## Test plan

- [x] Verified pane splitting works in zellij
- [x] Verified pane naming works in zellij
- [x] Existing tmux functionality still works
- [x] `cargo test` passes
- [x] `cargo clippy` passes