### PR TITLE
feat: add Nix flake for reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,16 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - run: cargo test
+
+  nix:
+    name: Nix Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@v17
+    - uses: DeterminateSystems/magic-nix-cache-action@v9
+    - name: Check flake
+      run: nix flake check --print-build-logs
+    - name: Build x86_64-linux-musl
+      run: nix build .#x86_64-linux-musl --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
   nix:
     name: Nix Build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@v17
     - uses: DeterminateSystems/magic-nix-cache-action@v9
     - name: Check flake
       run: nix flake check --print-build-logs
-    - name: Build x86_64-linux-musl
-      run: nix build .#x86_64-linux-musl --print-build-logs
+    - name: Build native package
+      run: nix build .#default --print-build-logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,8 @@ on:
     tags:
     - 'v*'
 
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: short
-  RUSTUP_MAX_RETRIES: 10
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -18,58 +15,46 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - target: x86_64-unknown-linux-musl
-          os: ubuntu-latest
-          os_label: linux
-          arch_label: amd64
+        - os: ubuntu-latest
+          package: x86_64-linux-musl
+          asset_name: gh-ghq-cd-linux-amd64
 
-        - target: aarch64-unknown-linux-musl
-          os: ubuntu-latest
-          os_label: linux
-          arch_label: arm64
+        - os: ubuntu-latest
+          package: aarch64-linux-musl
+          asset_name: gh-ghq-cd-linux-arm64
 
-        - target: x86_64-apple-darwin
-          os: macos-latest
-          os_label: darwin
-          arch_label: amd64
+        - os: macos-13
+          package: default
+          asset_name: gh-ghq-cd-darwin-amd64
 
-        - target: aarch64-apple-darwin
-          os: macos-latest
-          os_label: darwin
-          arch_label: arm64
+        - os: macos-latest
+          package: default
+          asset_name: gh-ghq-cd-darwin-arm64
 
     runs-on: ${{ matrix.os }}
-    env:
-      ASSET_NAME: gh-ghq-cd-${{ matrix.os_label }}-${{ matrix.arch_label }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.target }}
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v17
 
-    - name: Install cross [Linux]
-      if: matrix.os == 'ubuntu-latest'
-      uses: taiki-e/install-action@cross
+    - name: Setup Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@v9
 
-    - name: Build [Cargo]
-      if: matrix.os != 'ubuntu-latest'
-      run: cargo build --release --locked --target ${{ matrix.target }}
-
-    - name: Build [Cross]
-      if: matrix.os == 'ubuntu-latest'
-      run: cross build --release --locked --target ${{ matrix.target }}
+    - name: Build package
+      run: |
+        nix build .#${{ matrix.package }} --print-build-logs
 
     - name: Prepare binary
-      run: cp target/${{ matrix.target }}/release/gh-ghq-cd ${{ env.ASSET_NAME }}
+      run: |
+        cp result/bin/gh-ghq-cd ${{ matrix.asset_name }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.ASSET_NAME }}
-        path: ${{ env.ASSET_NAME }}
+        name: ${{ matrix.asset_name }}
+        path: ${{ matrix.asset_name }}
 
   release:
     name: Create Release
@@ -77,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Nix
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768032153,
+        "narHash": "sha256-6kD1MdY9fsE6FgSwdnx29hdH2UcBKs3/+JJleMShuJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768100056,
+        "narHash": "sha256-2GWCrsoWIuEXrzdKR2DPnoDhA5SqW7CGNO+Absni054=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "71a69fd633552550de7cb05cc149e4a99ff6f3b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,114 @@
+{
+  description = "GitHub CLI extension to fuzzy find and cd to a ghq managed repository";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    let
+      # Shared package definition
+      mkPackage = { pkgs, rustPlatform, target ? null }:
+        let
+          basePackage = {
+            pname = "gh-ghq-cd";
+            version = "0.8.0";
+            src = ./.;
+            cargoHash = "sha256-sMsq6otcvTgWj6w+jJ738NG9j038/XnPcNg7aBxzIzo=";
+            meta = {
+              description = "GitHub CLI extension to fuzzy find and cd to a ghq managed repository";
+              homepage = "https://github.com/cappyzawa/gh-ghq-cd";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "gh-ghq-cd";
+            };
+          };
+        in
+        rustPlatform.buildRustPackage (basePackage // pkgs.lib.optionalAttrs (target != null) {
+          CARGO_BUILD_TARGET = target;
+        });
+
+      # Helper to create rust platform with overlay
+      mkRustPlatform = pkgs:
+        let
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            targets = [
+              "x86_64-unknown-linux-musl"
+              "aarch64-unknown-linux-musl"
+            ];
+          };
+        in
+        pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rustPlatform = mkRustPlatform pkgs;
+      in
+      {
+        packages = {
+          # Native build for each system
+          gh-ghq-cd = mkPackage { inherit pkgs rustPlatform; };
+          default = self.packages.${system}.gh-ghq-cd;
+        } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          # Linux musl targets (static binaries) - built on x86_64-linux
+          x86_64-linux-musl =
+            let
+              pkgsCross = import nixpkgs {
+                inherit system overlays;
+                crossSystem = {
+                  config = "x86_64-unknown-linux-musl";
+                };
+              };
+              crossRustPlatform = mkRustPlatform pkgsCross;
+            in
+            mkPackage {
+              pkgs = pkgsCross;
+              rustPlatform = crossRustPlatform;
+              target = "x86_64-unknown-linux-musl";
+            };
+
+          aarch64-linux-musl =
+            let
+              pkgsCross = import nixpkgs {
+                inherit system overlays;
+                crossSystem = {
+                  config = "aarch64-unknown-linux-musl";
+                };
+              };
+              crossRustPlatform = mkRustPlatform pkgsCross;
+            in
+            mkPackage {
+              pkgs = pkgsCross;
+              rustPlatform = crossRustPlatform;
+              target = "aarch64-unknown-linux-musl";
+            };
+        };
+
+        apps = {
+          gh-ghq-cd = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.gh-ghq-cd;
+          };
+          default = self.apps.${system}.gh-ghq-cd;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            (pkgs.rust-bin.stable.latest.default)
+            pkgs.cargo-watch
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` to enable Nix-based installation and builds
- Migrate release workflow from cargo/cross to Nix builds for consistency
- Add Nix build validation to CI workflow

## Details

### flake.nix

Provides the following packages:

| System | Package | Target |
|--------|---------|--------|
| x86_64-linux | `default` | Native glibc |
| x86_64-linux | `x86_64-linux-musl` | Static musl |
| x86_64-linux | `aarch64-linux-musl` | Static musl (cross) |
| aarch64-linux | `default` | Native glibc |
| x86_64-darwin | `default` | Intel Mac |
| aarch64-darwin | `default` | Apple Silicon |

### Usage

```bash
# Run directly
nix run github:cappyzawa/gh-ghq-cd

# Use from another flake
inputs.gh-ghq-cd.url = "github:cappyzawa/gh-ghq-cd";
# → gh-ghq-cd.packages.aarch64-darwin.default
```

### Release workflow

Release binaries are now built using Nix, ensuring the same build definition is used for both:
- GitHub Release assets
- `nix build` / `nix run` installations

## Test plan

- [ ] CI passes (Nix build check on ubuntu-latest)
- [ ] Manual test: `nix build` on local machine
- [ ] Create a test tag to verify release workflow